### PR TITLE
Protocol init

### DIFF
--- a/Assignment3/protocol.py
+++ b/Assignment3/protocol.py
@@ -34,8 +34,7 @@ class Protocol:
         self._AuthNonce     = None
         self._g             = 2
         self._p             = 0xFFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3DC2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F83655D23DCA3AD961C62F356208552BB9ED529077096966D670C354E4ABC9804F1746C08CA18217C32905E462E36CE3BE39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9DE2BCBF6955817183995497CEA956AE515D2261898FA051015728E5A8AACAA68FFFFFFFFFFFFFFFF
-        self._ClientInitVal = b'Client protocol initiation message'
-        self._ServerInitVal = b'Server protocol initiation message'
+        self._InitVal       = b'Protocol initiation message'
         self._MWait         = None
         pass
 
@@ -84,11 +83,11 @@ class Protocol:
         self._MWait = datetime.now()
 
         # Encrypting the message
-        return self.EncryptAndProtectProtocol(pickle.dumps(msg))
+        return self._InitVal + (self.EncryptAndProtectProtocol(pickle.dumps(msg)))
 
     def IsMessagePartOfProtocol(self, message):
         """Checking if a received message is part of your protocol (called from app.py)"""
-        if self._BootstrapKey == None or self._SessionKey == None:
+        if message[:len(self._InitVal)] == self._InitVal:
             return True
         return False
 
@@ -100,6 +99,7 @@ class Protocol:
         Exception: if authentication fails
         """
         # Decrypting the message
+        message = message[len(self._InitVal):]
         message = self.DecryptAndVerifyProtocol(message, secret)
         msg = pickle.loads(message)
         
@@ -134,7 +134,7 @@ class Protocol:
             self.SetSessionKey(msg["DiffieHellman"])
 
 
-            return self.EncryptAndProtectProtocol(pickle.dumps(resp))
+            return self._InitVal + self.EncryptAndProtectProtocol(pickle.dumps(resp))
         else:
             # We are processing a response
             self.SetSessionKey(msg["DiffieHellman"]) # For now put 1, still waiting for the decryption implmentation, so i can get the DH part key from the received message.

--- a/Assignment3/protocol.py
+++ b/Assignment3/protocol.py
@@ -3,7 +3,6 @@ from Crypto.Random import get_random_bytes
 from Crypto.Random.random import randint
 from Crypto.Hash import SHA3_256
 from datetime import datetime
-import hashlib
 import pickle
 
 class Protocol:
@@ -165,13 +164,10 @@ class Protocol:
         if  self._DHExponent == None: 
                 raise Exception("The DH Exponent is not set yet.")
 
-        sessionkey = ((pow( OtherPublicDH, self._DHExponent)) % self._p)  
-        sessionkey_256b = hashlib.shake_256(
-            bytes(str(sessionkey), encoding='utf-8')).hexdigest(8)
-        self._SessionKey = bytes(sessionkey_256b, 'utf-8')
-        # self._BootstrapKey = None # no longer need this key
-        # self._DHExponent = None  # need to forget this exponent
-        #pass  #may delete later
+        sessionkey = ((pow( OtherPublicDH, self._DHExponent)) % self._p) 
+        hash_object = SHA3_256.new(data=bytes(str(sessionkey), "utf-8"))
+        self._SessionKey = hash_object.digest()
+        print(self._SessionKey)
 
     def EncryptAndProtectMessage(self, plain_text):
         """

--- a/Assignment3/protocol.py
+++ b/Assignment3/protocol.py
@@ -187,7 +187,10 @@ class Protocol:
         tag = bytes.fromhex(tag_hex)
 
         cipher = AES.new(self._SessionKey, AES.MODE_EAX, nonce=nonce)
-        plain_text = cipher.decrypt_and_verify(cipher_text, tag)
+        try:
+            plain_text = cipher.decrypt_and_verify(cipher_text, tag)
+        except ValueError as e:
+            raise ValueError("INCORRECT SESSION KEY: a message was sent with the incorrect session key. it may have been tampered with and it cannot be decrypted.")
         return plain_text.decode('ascii') 
 
     def EncryptAndProtectProtocol(self, plain_text):
@@ -212,5 +215,8 @@ class Protocol:
 
         self.SetBootstrapKey(self._AuthNonce, secret)
         cipher = AES.new(self._BootstrapKey, AES.MODE_EAX, nonce=nonce)
-        plain_text = cipher.decrypt_and_verify(cipher_text, tag)
+        try:
+            plain_text = cipher.decrypt_and_verify(cipher_text, tag)
+        except ValueError as e:
+            raise ValueError("INCORRECT SHARED SECRET: either your password is wrong, their password is wrong or someone has tampered with the message!")
         return plain_text


### PR DESCRIPTION
- Replaced Pickle with JSON as Pickle can give an attacker RCE abilities
- Added descriptive error messages when a MAC doesn't add up
- Blocked users from sending messages before the protocol has been secured
- Added initval to start of protocol initiation message to allow it to be identified by IsMessagePartOfProtocol
- Added timestamp checking
- Removed hashlib and just used Crypto.hash as there was no reason for two hashing libraries